### PR TITLE
Fix decorator order in group models

### DIFF
--- a/backend/src/models/GroupSeries.ts
+++ b/backend/src/models/GroupSeries.ts
@@ -29,52 +29,52 @@ import {
     @Column(DataType.INTEGER)
     id: number;
   
-    @Column(DataType.STRING)
     @AllowNull(false)
+    @Column(DataType.STRING)
     name: string;
   
-    @Column(DataType.STRING)
     @AllowNull(false)
+    @Column(DataType.STRING)
     baseGroupName: string;
   
     @Column(DataType.TEXT)
     description: string;
   
-    @Column(DataType.INTEGER)
     @Default(256)
     @AllowNull(false)
+    @Column(DataType.INTEGER)
     maxParticipants: number;
   
-    @Column(DataType.DECIMAL(5, 2))
     @Default(95.0)
     @AllowNull(false)
+    @Column(DataType.DECIMAL(5, 2))
     thresholdPercentage: number;
   
-    @Column(DataType.BOOLEAN)
     @Default(true)
     @AllowNull(false)
+    @Column(DataType.BOOLEAN)
     autoCreateEnabled: boolean;
   
     @Column(DataType.INTEGER)
     currentActiveGroupId: number;
   
-    @Column(DataType.INTEGER)
     @Default(2)
     @AllowNull(false)
+    @Column(DataType.INTEGER)
     nextGroupNumber: number;
   
     
     @ForeignKey(() => Company)
-    @Column(DataType.INTEGER)
     @AllowNull(false)
+    @Column(DataType.INTEGER)
     companyId: number;
   
     @BelongsTo(() => Company)
     company: Company;
   
     @ForeignKey(() => Whatsapp)
-    @Column(DataType.INTEGER)
     @AllowNull(false)
+    @Column(DataType.INTEGER)
     whatsappId: number;
   
     @BelongsTo(() => Whatsapp)

--- a/backend/src/models/Groups.ts
+++ b/backend/src/models/Groups.ts
@@ -35,12 +35,12 @@ class Groups extends Model<Groups> {
   @Column(DataType.INTEGER)
   id: number;
 
-  @Column(DataType.STRING)
   @AllowNull(false)
+  @Column(DataType.STRING)
   jid: string;
 
-  @Column(DataType.STRING)
   @AllowNull(false)
+  @Column(DataType.STRING)
   subject: string;
 
   @Column(DataType.TEXT)
@@ -73,13 +73,13 @@ class Groups extends Model<Groups> {
   @Column(DataType.DATE)
   lastSync: Date;
 
-  @Column(DataType.STRING)
   @Default("synced")
+  @Column(DataType.STRING)
   syncStatus: string;
 
-  @Column(DataType.BOOLEAN)
   @Default(false)
   @AllowNull(false)
+  @Column(DataType.BOOLEAN)
   isManaged: boolean;
 
   @Column(DataType.STRING)
@@ -88,32 +88,32 @@ class Groups extends Model<Groups> {
   @Column(DataType.INTEGER)
   groupNumber: number;
 
-  @Column(DataType.INTEGER)
   @Default(256)
   @AllowNull(false)
+  @Column(DataType.INTEGER)
   maxParticipants: number;
 
-  @Column(DataType.BOOLEAN)
   @Default(true)
   @AllowNull(false)
+  @Column(DataType.BOOLEAN)
   isActive: boolean;
 
   @Column(DataType.STRING)
   baseGroupName: string;
 
-  @Column(DataType.BOOLEAN)
   @Default(false)
   @AllowNull(false)
+  @Column(DataType.BOOLEAN)
   autoCreateNext: boolean;
 
-  @Column(DataType.DECIMAL(5, 2))
   @Default(95.0)
   @AllowNull(false)
+  @Column(DataType.DECIMAL(5, 2))
   thresholdPercentage: number;
 
   @ForeignKey(() => Company)
-  @Column(DataType.INTEGER)
   @AllowNull(false)
+  @Column(DataType.INTEGER)
   companyId: number;
 
   @BelongsTo(() => Company)


### PR DESCRIPTION
## Summary
- fix missing `@Column` errors in Groups and GroupSeries models by reordering decorators

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68409d830e9c832abd4a1858a9799a43